### PR TITLE
Solve disk creation issues for new OS versions

### DIFF
--- a/scripts/build_debian_image.sh
+++ b/scripts/build_debian_image.sh
@@ -89,7 +89,7 @@ sudo mkfs.vfat "${BOOT_PARTITION_DEVICE_ID}"
 echo "Encrypting and formatting the OS partition..."
 MAPPER_NAME=cr_root
 MAPPED_DEVICE_ID="/dev/mapper/${MAPPER_NAME}"
-MOUNT_POINT="/mnt/cr_root"
+MOUNT_POINT="/mnt/${MAPPER_NAME}"
 echo -n "${DISK_PASSWORD}" >"${KEY_FILE}"
 
 sudo cryptsetup --batch-mode --type luks1 --key-file "${KEY_FILE}" luksFormat "${OS_PARTITION_DEVICE_ID}"


### PR DESCRIPTION
Fix: Solved encrypted boot disk creation issues for new systems like Debian 12.

Improved the script a bit to make it flexible on devices names.
The encrypted mapped device name should be the same for both scripts to be able to work well.
Mainly added a `sed` script to ensure that Grub always set the correct root filesystem on Kernel boot command line.